### PR TITLE
Refactored file copying functionality

### DIFF
--- a/fs/copy.go
+++ b/fs/copy.go
@@ -1,29 +1,10 @@
 package aferox
 
 import (
-	"io/fs"
-
 	"github.com/spf13/afero"
+	"github.com/unmango/go/fs/internal"
 )
 
 func Copy(src, dest afero.Fs) error {
-	return afero.Walk(src, "",
-		func(path string, info fs.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if path == "" {
-				return nil // Skip root
-			}
-			if info.IsDir() {
-				return dest.Mkdir(path, info.Mode())
-			}
-
-			if f, err := src.Open(path); err != nil {
-				return err
-			} else {
-				return afero.WriteReader(dest, path, f)
-			}
-		},
-	)
+	return internal.Copy(src, dest)
 }

--- a/fs/internal/copy.go
+++ b/fs/internal/copy.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/spf13/afero"
+)
+
+func Copy(src, dest afero.Fs) error {
+	return afero.Walk(src, "",
+		func(path string, info fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if path == "" {
+				return nil // Skip root
+			}
+			if info.IsDir() {
+				return dest.Mkdir(path, info.Mode())
+			}
+
+			if f, err := src.Open(path); err != nil {
+				return fmt.Errorf("open %s: %w", path, err)
+			} else {
+				return afero.WriteReader(dest, path, f)
+			}
+		},
+	)
+}

--- a/fs/internal/copy_test.go
+++ b/fs/internal/copy_test.go
@@ -1,0 +1,98 @@
+package internal_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	"github.com/unmango/go/fs/internal"
+	. "github.com/unmango/go/testing/matcher"
+)
+
+var _ = Describe("Copy", func() {
+	It("should copy files", func() {
+		src := afero.NewMemMapFs()
+		err := afero.WriteFile(src, "test.txt", []byte("testing"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		dest := afero.NewMemMapFs()
+
+		err = internal.Copy(src, dest)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dest).To(ContainFileWithBytes("test.txt", []byte("testing")))
+	})
+
+	It("should copy directories", func() {
+		src := afero.NewMemMapFs()
+		err := src.Mkdir("test", os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		dest := afero.NewMemMapFs()
+
+		err = internal.Copy(src, dest)
+
+		Expect(err).NotTo(HaveOccurred())
+		stat, err := dest.Stat("test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.IsDir()).To(BeTrueBecause("the directory is created"))
+	})
+
+	It("should copy directories with files", func() {
+		src := afero.NewMemMapFs()
+		err := src.Mkdir("test", os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		err = afero.WriteFile(src, "test/test.txt", []byte("testing"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		dest := afero.NewMemMapFs()
+
+		err = internal.Copy(src, dest)
+
+		Expect(err).NotTo(HaveOccurred())
+		stat, err := dest.Stat("test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.IsDir()).To(BeTrueBecause("the directory is created"))
+		Expect(dest).To(ContainFileWithBytes("test/test.txt", []byte("testing")))
+	})
+
+	It("should copy multiple files", func() {
+		src := afero.NewMemMapFs()
+		err := afero.WriteFile(src, "test.txt", []byte("testing"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		err = afero.WriteFile(src, "test2.txt", []byte("testing2"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		dest := afero.NewMemMapFs()
+
+		err = internal.Copy(src, dest)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dest).To(ContainFileWithBytes("test.txt", []byte("testing")))
+		Expect(dest).To(ContainFileWithBytes("test2.txt", []byte("testing2")))
+	})
+
+	It("should copy a directory structure", func() {
+		src := afero.NewMemMapFs()
+		err := afero.WriteFile(src, "test.txt", []byte("testing"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		err = src.MkdirAll("test/other", os.ModeDir)
+		Expect(err).NotTo(HaveOccurred())
+		err = afero.WriteFile(src, "test/test2.txt", []byte("testing2"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		err = afero.WriteFile(src, "test/other/test3.txt", []byte("testing3"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		dest := afero.NewMemMapFs()
+
+		err = internal.Copy(src, dest)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dest).To(ContainFileWithBytes("test.txt", []byte("testing")))
+		stat, err := dest.Stat("test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.IsDir()).To(BeTrueBecause("the first directory is created"))
+		Expect(dest).To(ContainFileWithBytes("test/test2.txt", []byte("testing2")))
+		stat, err = dest.Stat("test/other")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.IsDir()).To(BeTrueBecause("the second directory is created"))
+		Expect(dest).To(ContainFileWithBytes("test/other/test3.txt", []byte("testing3")))
+	})
+})

--- a/fs/internal/internal_suite_test.go
+++ b/fs/internal/internal_suite_test.go
@@ -1,0 +1,13 @@
+package internal_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Suite")
+}


### PR DESCRIPTION
The file copying functionality has been refactored to improve code organization and error handling. The copy function was moved from the main package to an internal package. Error messages now provide more context by including the path of the file that caused the error. Additionally, comprehensive tests for this function have been added to ensure its correct operation under various scenarios such as copying files, directories, directory structures, and multiple files.
