### PR TITLE
os: Introduce a full I/O File interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ go.work*
 .direnv/
 *.out
 /result
+.claude/*.local.json

--- a/os/interface.go
+++ b/os/interface.go
@@ -33,6 +33,7 @@ type File interface {
 	fs.File
 	io.Closer
 	io.ReaderAt
+	io.Seeker
 	io.Writer
 	io.WriterAt
 	io.WriterTo

--- a/os/interface.go
+++ b/os/interface.go
@@ -16,6 +16,7 @@ type Cmd interface {
 type Env interface {
 	Clearenv()
 	Environ() []string
+	Expand(s string, mapping func(string) string) string
 	ExpandEnv(s string) string
 	Getenv(key string) string
 	IsPathSeparator(c uint8) bool
@@ -28,13 +29,23 @@ type Env interface {
 	UserHomeDir() (string, error)
 }
 
+type File interface {
+	fs.File
+	io.Closer
+	io.ReaderAt
+	io.Writer
+	io.WriterAt
+	io.WriterTo
+}
+
 type Fs interface {
 	CopyFS(dir string, fsys fs.FS) error
 	Chdir(dir string) error
 	Chmod(name string, mode FileMode) error
 	Chown(name string, uid, gid int) error
 	Chtimes(name string, atime, mtime time.Time) error
-	CreateTemp(dir, pattern string) (fs.File, error)
+	Create(name string) (File, error)
+	CreateTemp(dir, pattern string) (File, error)
 	DirFS(dir string) fs.FS
 	Lchown(name string, uid, gid int) error
 	Link(oldname, newname string) error
@@ -42,8 +53,9 @@ type Fs interface {
 	Mkdir(name string, mode FileMode) error
 	MkdirAll(path string, mode FileMode) error
 	MkdirTemp(dir, pattern string) (string, error)
-	Open(name string) (fs.File, error)
-	OpenInRoot(dir, name string) (fs.File, error)
+	Open(name string) (File, error)
+	OpenFile(name string, flag int, perm FileMode) (File, error)
+	OpenInRoot(dir, name string) (File, error)
 	OpenRoot(name string) (*Root, error)
 	ReadDir(name string) ([]DirEntry, error)
 	ReadFile(name string) ([]byte, error)

--- a/os/os.go
+++ b/os/os.go
@@ -94,7 +94,7 @@ var (
 
 type (
 	DirEntry     = os.DirEntry
-	File         = os.File
+	OsFile       = os.File
 	FileInfo     = os.FileInfo
 	FileMode     = os.FileMode
 	LinkError    = os.LinkError

--- a/os/system.go
+++ b/os/system.go
@@ -39,7 +39,11 @@ func (sys) CopyFS(dir string, fsys fs.FS) error {
 	return os.CopyFS(dir, fsys)
 }
 
-func (sys) CreateTemp(dir, pattern string) (fs.File, error) {
+func (sys) Create(name string) (File, error) {
+	return os.Create(name)
+}
+
+func (sys) CreateTemp(dir, pattern string) (File, error) {
 	return os.CreateTemp(dir, pattern)
 }
 
@@ -143,11 +147,15 @@ func (sys) MkdirTemp(dir, pattern string) (string, error) {
 	return os.MkdirTemp(dir, pattern)
 }
 
-func (sys) Open(name string) (fs.File, error) {
+func (sys) Open(name string) (File, error) {
 	return os.Open(name)
 }
 
-func (sys) OpenInRoot(dir, name string) (fs.File, error) {
+func (sys) OpenFile(name string, flag int, perm FileMode) (File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (sys) OpenInRoot(dir, name string) (File, error) {
 	return os.OpenInRoot(dir, name)
 }
 


### PR DESCRIPTION
The `os` package's `Fs` interface methods previously returned `fs.File`,
which is limited to read-only operations. This commit introduces a new
`File` interface that embeds `io.Closer`, `io.ReaderAt`, `io.Writer`,
`io.WriterAt`, and `io.WriterTo`, closely mirroring the capabilities
of `*os.File` from the standard library. `Fs` methods such as `Create`,
`CreateTemp`, `Open`, `OpenFile`, and `OpenInRoot` are updated to
return this more capable `File` type. The existing `os.File` type alias
is renamed to `OsFile` to avoid name collision.

Additionally, the `Env` interface gains an `Expand` method, providing
functionality similar to `os.Expand` for environment variable expansion.
The `.gitignore` file is updated to ignore `.claude/*.local.json` files.
